### PR TITLE
fix: Copy button now copies full curl commands in Dataset API

### DIFF
--- a/Research Papers/QuinBeta21ab1/index.html
+++ b/Research Papers/QuinBeta21ab1/index.html
@@ -199,17 +199,17 @@ model = QuinLoader.from_pretrained(
           <h4 style="margin-top:12px">Dataset API (curl)</h4>
           <div class="curl-row">
             <pre style="flex:1;margin:0;padding:8px;border-radius:8px;">curl -X GET "https://datasets-server.huggingface.co/rows?dataset=DrChamyoung%2FQuinbeta5.2DataSets&config=default&split=train&offset=0&length=100"</pre>
-            <button class="copy" data-clip="curl -X GET \"https://datasets-server.huggingface.co/rows?dataset=DrChamyoung%2FQuinbeta5.2DataSets&config=default&split=train&offset=0&length=100\"">Copy</button>
+            <button class="copy" data-clip='curl -X GET "https://datasets-server.huggingface.co/rows?dataset=DrChamyoung%2FQuinbeta5.2DataSets&config=default&split=train&offset=0&length=100"'>Copy</button>
           </div>
 
           <div style="margin-top:10px" class="curl-row">
             <pre style="flex:1;margin:0;padding:8px;border-radius:8px;">curl -X GET "https://datasets-server.huggingface.co/splits?dataset=DrChamyoung%2FQuinbeta5.2DataSets"</pre>
-            <button class="copy" data-clip="curl -X GET \"https://datasets-server.huggingface.co/splits?dataset=DrChamyoung%2FQuinbeta5.2DataSets\"">Copy</button>
+            <button class="copy" data-clip='curl -X GET "https://datasets-server.huggingface.co/splits?dataset=DrChamyoung%2FQuinbeta5.2DataSets"'>Copy</button>
           </div>
 
           <div style="margin-top:10px" class="curl-row">
             <pre style="flex:1;margin:0;padding:8px;border-radius:8px;">curl -X GET "https://huggingface.co/api/datasets/DrChamyoung/Quinbeta5.2DataSets/parquet/default/train"</pre>
-            <button class="copy" data-clip="curl -X GET \"https://huggingface.co/api/datasets/DrChamyoung/Quinbeta5.2DataSets/parquet/default/train\"">Copy</button>
+            <button class="copy" data-clip='curl -X GET "https://huggingface.co/api/datasets/DrChamyoung/Quinbeta5.2DataSets/parquet/default/train"'>Copy</button>
           </div>
 
           <hr style="margin:12px 0;border-color:rgba(148,163,184,0.2)">


### PR DESCRIPTION
- Changed data-clip attribute to use single quotes instead of double quotes with escaped backslashes
- This prevents HTML parsing issues that were truncating the clipboard content
- All three curl commands in Dataset API section now copy correctly

Fixes #2